### PR TITLE
Unused images

### DIFF
--- a/R.swift.podspec
+++ b/R.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "R.swift"
-  spec.version      = "5.0.5"
+  spec.version      = "5.0.6"
   spec.license      = "MIT"
 
   spec.summary      = "Get strong typed, autocompleted resources like images, fonts and segues in Swift projects"

--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -32,6 +32,7 @@ public struct CallInformation {
   let sdkRootURL: URL
   let platformURL: URL
   let objcCompat: Bool
+  let unusedImages: Bool
 
   public init(
     outputURL: URL,
@@ -54,7 +55,8 @@ public struct CallInformation {
     sourceRootURL: URL,
     sdkRootURL: URL,
     platformURL: URL,
-    objcCompat: Bool
+    objcCompat: Bool,
+    unusedImages: Bool
   ) {
     self.outputURL = outputURL
     self.rswiftIgnoreURL = rswiftIgnoreURL
@@ -77,6 +79,7 @@ public struct CallInformation {
     self.sdkRootURL = sdkRootURL
     self.platformURL = platformURL
     self.objcCompat = objcCompat
+    self.unusedImages = unusedImages
   }
 
 

--- a/Sources/RswiftCore/ResourceTypes/Image.swift
+++ b/Sources/RswiftCore/ResourceTypes/Image.swift
@@ -12,6 +12,8 @@ import Foundation
 struct Image: WhiteListedExtensionsResourceType {
   // See "Supported Image Formats" on https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/
   static let supportedExtensions: Set<String> = ["tiff", "tif", "jpg", "jpeg", "gif", "png", "bmp", "bmpf", "ico", "cur", "xbm"]
+  private static let extensions = Image.supportedExtensions.joined(separator: "|")
+  private static let regex = try! NSRegularExpression(pattern: "(~(ipad|iphone))?(@[2,3]x)?\\.(\(extensions))$", options: .caseInsensitive)
 
   let name: String
 
@@ -24,10 +26,8 @@ struct Image: WhiteListedExtensionsResourceType {
       throw ResourceParsingError.parsingFailed("Filename and/or extension could not be parsed from URL: \(url.absoluteString)")
     }
 
-    let extensions = Image.supportedExtensions.joined(separator: "|")
-    let regex = try! NSRegularExpression(pattern: "(~(ipad|iphone))?(@[2,3]x)?\\.(\(extensions))$", options: .caseInsensitive)
     let fullFileNameRange = NSRange(location: 0, length: filename.count)
     let pathExtensionToUse = (pathExtension == "png") ? "" : ".\(pathExtension)"
-    name = regex.stringByReplacingMatches(in: filename, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: fullFileNameRange, withTemplate: pathExtensionToUse)
+    name = Image.regex.stringByReplacingMatches(in: filename, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: fullFileNameRange, withTemplate: pathExtensionToUse)
   }
 }

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -69,6 +69,21 @@ public struct RswiftCore {
       if callInformation.objcCompat {
         fileContents += objcConvertibles.compactMap { $0.objcCode(prefix: "") }.joined(separator: "\n") + "\n"
       }
+        
+      let allImages =
+        resources.images.map { $0.name } +
+        resources.assetFolders.flatMap { $0.imageAssets }
+
+      let allUsedImages =
+        resources.nibs.flatMap { $0.usedImageIdentifiers } +
+        resources.storyboards.flatMap { $0.usedImageIdentifiers }
+
+      let unusedImages = Set(allImages).subtracting(Set(allUsedImages))
+      let unusedImageGeneratedNames = unusedImages.map { SwiftIdentifier(name: $0).description }.uniqueAndSorted()
+
+      fileContents += "/* Potentially Unused Images\n"
+      fileContents += unusedImageGeneratedNames.joined(separator: "\n")
+      fileContents += "\n*/"
 
       // Write file if we have changes
       let currentFileContents = try? String(contentsOf: callInformation.outputURL, encoding: .utf8)

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -69,21 +69,23 @@ public struct RswiftCore {
       if callInformation.objcCompat {
         fileContents += objcConvertibles.compactMap { $0.objcCode(prefix: "") }.joined(separator: "\n") + "\n"
       }
-        
-      let allImages =
-        resources.images.map { $0.name } +
-        resources.assetFolders.flatMap { $0.imageAssets }
+    
+      if callInformation.unusedImages {
+        let allImages =
+          resources.images.map { $0.name } +
+          resources.assetFolders.flatMap { $0.imageAssets }
 
-      let allUsedImages =
-        resources.nibs.flatMap { $0.usedImageIdentifiers } +
-        resources.storyboards.flatMap { $0.usedImageIdentifiers }
+        let allUsedImages =
+          resources.nibs.flatMap { $0.usedImageIdentifiers } +
+          resources.storyboards.flatMap { $0.usedImageIdentifiers }
 
-      let unusedImages = Set(allImages).subtracting(Set(allUsedImages))
-      let unusedImageGeneratedNames = unusedImages.map { SwiftIdentifier(name: $0).description }.uniqueAndSorted()
+        let unusedImages = Set(allImages).subtracting(Set(allUsedImages))
+        let unusedImageGeneratedNames = unusedImages.map { SwiftIdentifier(name: $0).description }.uniqueAndSorted()
 
-      fileContents += "/* Potentially Unused Images\n"
-      fileContents += unusedImageGeneratedNames.joined(separator: "\n")
-      fileContents += "\n*/"
+        fileContents += "/* Potentially Unused Images\n"
+        fileContents += unusedImageGeneratedNames.joined(separator: "\n")
+        fileContents += "\n*/"
+      }
 
       // Write file if we have changes
       let currentFileContents = try? String(contentsOf: callInformation.outputURL, encoding: .utf8)

--- a/Sources/RswiftCore/Util/Glob.swift
+++ b/Sources/RswiftCore/Util/Glob.swift
@@ -60,8 +60,6 @@ public class Glob: Collection {
 
   public static let defaultBlacklistedDirectories = ["node_modules", "Pods"]
 
-  private var isDirectoryCache = [String: Bool]()
-
   public let behavior: Behavior
   public let blacklistedDirectories: [String]
   var paths = [String]()
@@ -105,8 +103,6 @@ public class Glob: Collection {
     paths = Array(Set(paths)).sorted { lhs, rhs in
       lhs.compare(rhs) != ComparisonResult.orderedDescending
     }
-
-    clearCaches()
   }
   
   // MARK: Subscript Support
@@ -187,19 +183,8 @@ public class Glob: Collection {
   }
 
   private func isDirectory(path: String) -> Bool {
-    if let isDirectory = isDirectoryCache[path] {
-      return isDirectory
-    }
-
     var isDirectoryBool = ObjCBool(false)
-    let isDirectory = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectoryBool) && isDirectoryBool.boolValue
-    isDirectoryCache[path] = isDirectory
-
-    return isDirectory
-  }
-
-  private func clearCaches() {
-    isDirectoryCache.removeAll()
+    return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectoryBool) && isDirectoryBool.boolValue
   }
 
   private func populateFiles(gt: glob_t, includeFiles: Bool) {

--- a/Sources/RswiftCore/Util/SwiftIdentifier.swift
+++ b/Sources/RswiftCore/Util/SwiftIdentifier.swift
@@ -160,7 +160,7 @@ private let blacklistedCharacters: CharacterSet = {
 }()
 
 // Based on https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID413
-private let SwiftKeywords = [
+private let SwiftKeywords = Set([
   // Keywords used in declarations
   "associatedtype", "class", "deinit", "enum", "extension", "fileprivate", "func", "import", "init", "inout", "internal", "let", "open", "operator", "private", "protocol", "public", "static", "struct", "subscript", "typealias", "var",
 
@@ -175,5 +175,4 @@ private let SwiftKeywords = [
 
   // Keywords from Swift 2 that are still reserved
   "__COLUMN__", "__FILE__", "__FUNCTION__", "__LINE__",
-]
-
+])

--- a/Sources/rswift/main.swift
+++ b/Sources/rswift/main.swift
@@ -37,6 +37,7 @@ extension ProcessInfo {
 struct CommanderFlags {
   static let version = Flag("version", description: "Prints version information about this release.")
   static let objc = Flag("objc", description: "Generates ObjC compatible definitions in RObjc")
+  static let unusedImages = Flag("unused-images", description: "Appends a list of images that aren't used in xibs or storyboards to check against if they are still used.")
 }
 
 // Default values for non-optional Commander Options
@@ -84,9 +85,10 @@ let generate = command(
   CommanderOptions.inputOutputFilesValidation,
   
   CommanderFlags.objc,
+  CommanderFlags.unusedImages,
 
   CommanderArguments.outputPath
-) { importModules, accessLevel, rswiftIgnore, inputOutputFilesValidation, objc, outputPath in
+) { importModules, accessLevel, rswiftIgnore, inputOutputFilesValidation, objc, unusedImages, outputPath in
 
   let processInfo = ProcessInfo()
 
@@ -179,7 +181,8 @@ let generate = command(
     sourceRootURL: URL(fileURLWithPath: sourceRootPath),
     sdkRootURL: URL(fileURLWithPath: sdkRootPath),
     platformURL: URL(fileURLWithPath: platformPath),
-    objcCompat: objc
+    objcCompat: objc,
+    unusedImages: unusedImages
   )
 
   try RswiftCore.run(callInformation)


### PR DESCRIPTION
Adds opt-in support for identifying images that are unused by xibs and storyboards, and appends them to the end of the generated file in a comment. This can make it easy to scan your swift code for remaining uses.

Also makes a couple performance improvements. They should be universal, but they at least make significant decreases in execution time for my projects.